### PR TITLE
Use Theme.Holo when running on ICS

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -5,7 +5,7 @@
   android:versionName="0.9"
   android:installLocation="auto">
 
-    <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="10" />
+    <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="14" />
 
     <uses-permission android:name="android.permission.NFC" />
     <uses-feature android:name="android.hardware.nfc" />


### PR DESCRIPTION
I changed one line in AndroidManifest.xml so the app uses the new Holo theme when running on Android 4.0. It should work normally on other Android versions and just use the old theme.
